### PR TITLE
Fix: Elastic Beanstalk 배포 실패 해결을 위해 Java PID를 appstart에서 직접 저장

### DIFF
--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -6,6 +6,7 @@ files:
     content: |
       #!/usr/bin/env bash
       JAR_PATH=/var/app/current/application.jar
+      PID_DIR=/var/pids
 
       # load JAVA_OPTS from Beanstalk envvars file
       if [ -f /opt/elasticbeanstalk/support/envvars ]; then
@@ -13,5 +14,7 @@ files:
       fi
 
       # run app
-      killall java
-      java -Dfile.encoding=UTF-8 -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} $JAVA_OPTS -jar $JAR_PATH
+      killall java || true
+      mkdir -p $PID_DIR
+      java -Dfile.encoding=UTF-8 -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} $JAVA_OPTS -jar $JAR_PATH &
+      echo $! > $PID_DIR/web.pid


### PR DESCRIPTION
## 🔥 Related Issue

## 🏃‍ Task

## 📄 Reference